### PR TITLE
fix duplicate symbol error and emscripten build error

### DIFF
--- a/Samplers/OwenScrambling.h
+++ b/Samplers/OwenScrambling.h
@@ -33,7 +33,7 @@
 #include "Random.h"
 
 //seed has to stay the same for a given dimention
-uint32_t OwenScrambling(uint32_t sobolPoint, uint32_t seed, const uint32_t owen_tree_depth) {
+inline uint32_t OwenScrambling(uint32_t sobolPoint, uint32_t seed, const uint32_t owen_tree_depth) {
 
     RNG scramble_rng;
 

--- a/Samplers/SobolGenerator1D.h
+++ b/Samplers/SobolGenerator1D.h
@@ -39,12 +39,6 @@
 #include <sstream>
 #include <fstream>
 
-#include "OwenScrambling.h"
-
-#ifdef _MSC_VER 
-typedef unsigned int uint;
-#endif
-
 inline uint32_t ReverseBits(uint32_t n) {
     n = (n << 16) | (n >> 16);
     n = ((n & 0x00ff00ff) << 8) | ((n & 0xff00ff00) >> 8);
@@ -124,7 +118,7 @@ public:
     inline friend std::ostream& operator<<(std::ostream& out, const SobolGenerator1D& sobol){
 
         out << sobol.d << "\t" << sobol.s << "\t" << sobol.a  << "\t";
-        for (uint i = 0; i < sobol.s; ++i) {
+        for (uint32_t i = 0; i < sobol.s; ++i) {
             out << sobol.m[i] << " ";
         }
 

--- a/cascadedSobol.cpp
+++ b/cascadedSobol.cpp
@@ -33,6 +33,7 @@
 #include "CLI11.hpp"
 
 #include "Samplers/SobolGenerator1D.h"
+#include "Samplers/OwenScrambling.h"
 
 
 using namespace std;


### PR DESCRIPTION
the `uint` caused a build error when using emscripten, so, since its only used once, I removed the #define and used `uint32_t` explicitly instead.

I also fixed two issues that interfered with using this code as a header-only library in a subproject: `OwenScrambling` was defined inline in the header, but not marked inline, which caused duplicate symbols. Also, since `OwenScrambling` was not actually used in `Samplers/SobolGenerator1D.h`, I moved its #include to the main executable. 

This now compiles on Windows/Linux/macOS/emscripten for me. Check [here](https://github.com/wkjarosz/SamplinSafari/actions) if interested.